### PR TITLE
feat: implement retry logic with exponential backoff (Tickets 2.1 & 2.2)

### DIFF
--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -24,9 +24,14 @@ export async function askCommand(prompt: string, options: AskOptions): Promise<v
     
     const client = new AnthropicClient(config);
     
-    const { content, usage } = await client.sendMessage([
-      { role: 'user', content: prompt, timestamp: Date.now() }
-    ]);
+    const { content, usage } = await client.sendMessage(
+      [{ role: 'user', content: prompt, timestamp: Date.now() }],
+      (attempt, delay) => {
+        if (options.debug) {
+          console.log(`[DEBUG] Retry attempt ${attempt} after ${Math.round(delay)}ms`);
+        }
+      }
+    );
     
     console.log(content);
     console.log();

--- a/src/lib/anthropic-client.ts
+++ b/src/lib/anthropic-client.ts
@@ -1,15 +1,16 @@
 /**
  * Anthropic API Client Wrapper
- * Provides simplified interface for sending messages and tracking usage
+ * Provides simplified interface for sending messages with retry logic and usage tracking
  */
 
 import Anthropic from '@anthropic-ai/sdk';
 import { Config, Message, UsageStats } from '../types/index.js';
 import { classifyError } from './errors.js';
+import { withRetry } from './retry.js';
 
 /**
  * Client for interacting with Anthropic's Claude API
- * Handles message sending, response parsing, and cost calculation
+ * Handles message sending, response parsing, cost calculation, and automatic retries
  */
 export class AnthropicClient {
   private client: Anthropic;
@@ -27,48 +28,55 @@ export class AnthropicClient {
   }
 
   /**
-   * Send messages to Anthropic API and receive response
+   * Send messages to Anthropic API and receive response with automatic retry
    * @param messages - Array of conversation messages (user/assistant)
+   * @param onRetry - Optional callback invoked before each retry attempt
    * @returns Object containing response content and usage statistics
    * @throws AIClientError - Classified error based on failure type
    */
   async sendMessage(
-    messages: Message[]
+    messages: Message[],
+    onRetry?: (attempt: number, delay: number) => void
   ): Promise<{ content: string; usage: UsageStats }> {
-    try {
-      // Filter out 'system' role messages and convert to Anthropic SDK format
-      const apiMessages = messages
-        .filter((m) => m.role !== 'system')
-        .map((m) => ({
-          role: m.role as 'user' | 'assistant',
-          content: m.content,
-        }));
+    const operation = async () => {
+      try {
+        // Filter out 'system' role messages and convert to Anthropic SDK format
+        const apiMessages = messages
+          .filter((m) => m.role !== 'system')
+          .map((m) => ({
+            role: m.role as 'user' | 'assistant',
+            content: m.content,
+          }));
 
-      // Call Anthropic API
-      const response = await this.client.messages.create({
-        model: this.config.defaultModel,
-        max_tokens: this.config.maxTokens,
-        temperature: this.config.temperature,
-        messages: apiMessages,
-      });
+        // Call Anthropic API
+        const response = await this.client.messages.create({
+          model: this.config.defaultModel,
+          max_tokens: this.config.maxTokens,
+          temperature: this.config.temperature,
+          messages: apiMessages,
+        });
 
-      // Extract text content from response (first text block per spec)
-      const content =
-        response.content[0]?.type === 'text'
-          ? response.content[0].text
-          : '';
+        // Extract text content from response (first text block per spec)
+        const content =
+          response.content[0]?.type === 'text'
+            ? response.content[0].text
+            : '';
 
-      // Calculate usage statistics and costs
-      const usage = this.calculateUsage(
-        response.usage.input_tokens,
-        response.usage.output_tokens
-      );
+        // Calculate usage statistics and costs
+        const usage = this.calculateUsage(
+          response.usage.input_tokens,
+          response.usage.output_tokens
+        );
 
-      return { content, usage };
-    } catch (error: any) {
-      // Classify error for consistent handling upstream
-      throw classifyError(error);
-    }
+        return { content, usage };
+      } catch (error: any) {
+        // Classify error for consistent handling upstream
+        throw classifyError(error);
+      }
+    };
+
+    // Wrap operation with retry logic
+    return withRetry(operation, this.config.retry, onRetry);
   }
 
   /**

--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -1,0 +1,55 @@
+/**
+ * Retry utility with exponential backoff
+ * Handles transient failures gracefully with configurable retry strategy
+ */
+
+import { isRetryable } from './errors.js';
+import { RetryConfig } from '../types/index.js';
+
+/**
+ * Execute an operation with automatic retry on transient failures
+ * @param operation - Async function to execute (and potentially retry)
+ * @param config - Retry configuration (maxRetries, baseDelayMs, maxDelayMs)
+ * @param onRetry - Optional callback invoked before each retry attempt
+ * @returns Promise resolving to operation result
+ * @throws Last error if all retries exhausted or non-retryable error encountered
+ */
+export async function withRetry<T>(
+  operation: () => Promise<T>,
+  config: RetryConfig,
+  onRetry?: (attempt: number, delay: number) => void
+): Promise<T> {
+  let lastError: Error;
+
+  for (let attempt = 0; attempt <= config.maxRetries; attempt++) {
+    try {
+      return await operation();
+    } catch (error: any) {
+      lastError = error;
+
+      // Don't retry if error is not retryable or we've exhausted retries
+      if (!isRetryable(error) || attempt === config.maxRetries) {
+        throw error;
+      }
+
+      // Calculate exponential backoff: baseDelayMs * 2^attempt
+      const exponentialDelay = config.baseDelayMs * Math.pow(2, attempt);
+      
+      // Cap at maxDelayMs
+      const delay = Math.min(exponentialDelay, config.maxDelayMs);
+
+      // Add random jitter (0-250ms) to prevent thundering herd
+      const jitter = Math.random() * 250;
+      const totalDelay = delay + jitter;
+
+      // Notify about retry attempt
+      onRetry?.(attempt + 1, totalDelay);
+
+      // Wait before retrying
+      await new Promise(resolve => setTimeout(resolve, totalDelay));
+    }
+  }
+
+  // Should never reach here, but TypeScript needs this
+  throw lastError!;
+}


### PR DESCRIPTION
- Add withRetry() utility with exponential backoff and jitter
  - Exponential delay: baseDelayMs * 2^attempt
  - Cap delay at maxDelayMs (8000ms default)
  - Random jitter (0-250ms) to prevent thundering herd
  - Only retry errors where isRetryable() returns true

- Update AnthropicClient.sendMessage() to use retry logic
  - Wrap API operation with withRetry()
  - Add optional onRetry callback parameter
  - Automatic retry on RateLimitError, ServerError, NetworkError
  - Non-retryable errors (AuthError, ValidationError) fail immediately

- Update ask command to use retry callback in debug mode
  - Display retry attempts with delay when --debug flag used
  - Shows 'Retry attempt N after Xms' for visibility

Implements exponential backoff retry strategy per spec section 7.1 Closes #13 (Ticket 2.1)
Closes #12 (Ticket 2.2)

Phase 2: Resilience & Cost Tracking - Complete ✅